### PR TITLE
use APP_ENV to get app env setting in blade

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
 <head>
-    @if(environment('production')
+    @if(env('APP_ENV') === 'production')
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-114740882-1"></script>
     <script>
         window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
we want to check the env setting and not send analytics to google if in local or staging. 

This uses the app_env from .env to check around the analytics tag.